### PR TITLE
upgrade to nixpkgs 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,16 +41,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1714043624,
-        "narHash": "sha256-Xn2r0Jv95TswvPlvamCC46wwNo8ALjRCMBJbGykdhcM=",
+        "lastModified": 1720042825,
+        "narHash": "sha256-A0vrUB6x82/jvf17qPCpxaM+ulJnD8YZwH9Ci0BsAzE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86853e31dc1b62c6eeed11c667e8cdd0285d4411",
+        "rev": "e1391fb22e18a36f57e6999c7a9f966dc80ac073",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.11",
+        "ref": "release-24.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -62,32 +62,32 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1702823833,
-        "narHash": "sha256-Sreo1VEMSwS/T83QxXeN1cDtgXWXPMibGYfQ8pLLSVc=",
+        "lastModified": 1720391164,
+        "narHash": "sha256-RrJsSelbJ/SCrnCH0yLEvgVSKVoG7b45Qhf/6fOiQ8I=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "34eda458bd3f6bad856a99860184d775bc1dd588",
+        "rev": "05098ab6e48684c573d7033bd583b1eea2f5f851",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "2311.5.3",
+        "ref": "2405.5.4",
         "repo": "nixos-wsl",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701952659,
-        "narHash": "sha256-TJv2srXt6fYPUjxgLAL0cy4nuf1OZD4KuA1TrCiQqg0=",
+        "lastModified": 1720954236,
+        "narHash": "sha256-1mEKHp4m9brvfQ0rjCca8P1WHpymK3TOr3v34ydv9bs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4372c4924d9182034066c823df76d6eaf1f4ec4",
+        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -110,16 +110,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714971268,
-        "narHash": "sha256-IKwMSwHj9+ec660l+I4tki/1NRoeGpyA2GdtdYpAgEw=",
+        "lastModified": 1720954236,
+        "narHash": "sha256-1mEKHp4m9brvfQ0rjCca8P1WHpymK3TOr3v34ydv9bs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "27c13997bf450a01219899f5a83bd6ffbfc70d3c",
+        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,18 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
 
     # Nixpkgs unstable
     # pull request: https://github.com/NixOS/nixpkgs/pull/311047
     nixpkgs-unstable.url = "github:nixos/nixpkgs/817c3eccc985907e3cf8137232aa9a9715f695c8";
 
     # Home manager
-    home-manager.url = "github:nix-community/home-manager/release-23.11";
+    home-manager.url = "github:nix-community/home-manager/release-24.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     # NixOS WSL
-    nixos-wsl.url = "github:nix-community/nixos-wsl/2311.5.3";
+    nixos-wsl.url = "github:nix-community/nixos-wsl/2405.5.4";
   };
 
   outputs =

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -115,7 +115,9 @@
   };
   programs.zsh = {
     enable = true;
-    enableAutosuggestions = true;
+    autosuggestion = {
+      enable = true;
+    };
     initExtraFirst = ''
       source $HOME/.p10k.zsh
       ${builtins.readFile ./zsh/instant-prompt.zsh}

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -48,7 +48,10 @@
     };
   };
   programs.command-not-found.enable = true;
-  programs.direnv.enable = true;
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
   programs.fzf.enable = true;
   programs.gh = {
     enable = true;

--- a/home-manager/darwin/default.nix
+++ b/home-manager/darwin/default.nix
@@ -52,7 +52,7 @@
   systemd.user.startServices = "sd-switch";
 
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
-  home.stateVersion = "23.11";
+  home.stateVersion = "24.05";
 
   home.file."Brewfile".text = (builtins.readFile ./Brewfile);
   home.file."Brewfile.lock.json".text = (builtins.readFile ./Brewfile.lock.json);

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -52,7 +52,7 @@
   systemd.user.startServices = "sd-switch";
 
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
-  home.stateVersion = "23.11";
+  home.stateVersion = "24.05";
 
   services.gpg-agent = {
     enable = true;

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -60,7 +60,7 @@
     defaultCacheTtl = 86400; # 1 day
     enableSshSupport = true;
     maxCacheTtl = 604800; # 1 week
-    pinentryFlavor = "curses";
+    pinentryPackage = pkgs.pinentry-curses;
   };
   services.syncthing.enable = true;
 }

--- a/hosts/vm/configuration.nix
+++ b/hosts/vm/configuration.nix
@@ -91,7 +91,7 @@
   };
 
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
-  system.stateVersion = "23.11";
+  system.stateVersion = "24.05";
 
   programs.zsh.enable = true;
   users.defaultUserShell = pkgs.zsh;

--- a/hosts/wsl/configuration.nix
+++ b/hosts/wsl/configuration.nix
@@ -22,7 +22,7 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "23.11"; # Did you read the comment?
+  system.stateVersion = "24.05"; # Did you read the comment?
 
   # NOTE: error: Neither nixpkgs.hostPlatform nor the legacy option nixpkgs.system has been set.
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";


### PR DESCRIPTION
- feat: upgrade to 24.05
- fix: replace pinentryFlavor with pinentryPackage
- fix: autosuggestion has been renamed
- feat: enable nix-direnv of direnv
