### PR TITLE
feat: add vm/run task to start VM for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 tmp/*
 !tmp/.keep
+
+# VM build artifacts
+result
+*.qcow2

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 vm/run:
 ifeq ($(_UNAME),Linux)
 	nix build ".#nixosConfigurations.vm.config.system.build.vm"
-	./result/bin/run-nixos-vm
+	QEMU_NET_OPTS="hostfwd=tcp::2222-:22" ./result/bin/run-nixos-vm
 else
 	$(error vm/run is only supported on Linux)
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ _UNAME := $(shell uname)
 _ARCH := $(shell uname -m)
 _WSL_DISTRO := $(WSL_DISTRO_NAME)
 
-.PHONY: all fmt update dry-run switch os/dry-run os/switch
+.PHONY: all fmt update dry-run switch os/dry-run os/switch vm/run
 
 all: fmt
 
@@ -67,4 +67,12 @@ else ifeq ($(_UNAME),Darwin)
 	$(error Darwin is not supported)
 else ifeq ($(_UNAME),Linux)
 	sudo nixos-rebuild switch --flake ".#vm"
+endif
+
+vm/run:
+ifeq ($(_UNAME),Linux)
+	nix build ".#nixosConfigurations.vm.config.system.build.vm"
+	./result/bin/run-nixos-vm
+else
+	$(error vm/run is only supported on Linux)
 endif


### PR DESCRIPTION
## Summary
- Add new `make vm/run` task to build and start a QEMU VM for testing NixOS configuration
- Uses `nix build` to build the VM image from flake
- Only supported on Linux systems

## Test plan
- [x] Run `make vm/run` on Linux to verify VM builds and starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)