### PR TITLE
feat: integrate home-manager into VM configuration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,6 +95,8 @@ The configuration includes:
 - Set zsh as the default shell.
 - Enable Avahi so the virtual machine is accessible via the \*.local domain.
 - Set Asia/Taipei as the timezone.
+- Home-manager is integrated as a NixOS module, so user configuration is applied on boot.
+- Default password `nixos` for testing (change immediately with `passwd`).
 
 ## hosts/wsl
 
@@ -112,3 +114,4 @@ Automation commands for building and deployment:
 - `make switch`: Apply home-manager configuration.
 - `make os/dry-run`: Validate NixOS system configuration.
 - `make os/switch`: Apply NixOS system configuration.
+- `make vm/run`: Build and start a QEMU VM for testing (Linux only). Allocates half of host CPU and memory, forwards SSH to port 2222.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ _NIX_FILES := $(shell find . -name '*.nix')
 _UNAME := $(shell uname)
 _ARCH := $(shell uname -m)
 _WSL_DISTRO := $(WSL_DISTRO_NAME)
+_HALF_CPUS := $(shell echo $$(( $$(nproc) / 2 )))
+_HALF_MEM := $(shell free -m | awk '/^Mem:/{print int($$2/2)}')
 
 .PHONY: all fmt update dry-run switch os/dry-run os/switch vm/run
 
@@ -72,7 +74,7 @@ endif
 vm/run:
 ifeq ($(_UNAME),Linux)
 	nix build ".#nixosConfigurations.vm.config.system.build.vm"
-	QEMU_NET_OPTS="hostfwd=tcp::2222-:22" ./result/bin/run-nixos-vm
+	QEMU_OPTS="-m $(_HALF_MEM) -smp $(_HALF_CPUS)" QEMU_NET_OPTS="hostfwd=tcp::2222-:22" ./result/bin/run-nixos-vm
 else
 	$(error vm/run is only supported on Linux)
 endif

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Ensure the VM boots with UEFI and has three partitions labeled "boot", "nixos", 
 sudo nixos-rebuild switch --flake .#vm
 ```
 
+To test VM configuration locally with QEMU (Linux only):
+
+```bash
+make vm/run
+```
+
+This builds and starts a VM with half of host CPU and memory, SSH forwarded to port 2222. Login credentials: `nixos` / `nixos`. Connect via SSH:
+
+```bash
+ssh -p 2222 nixos@localhost
+```
+
 To ensure that the Home Manager configuration is evaluable, also known as a dry run:
 
 ```bash

--- a/hosts/vm/configuration.nix
+++ b/hosts/vm/configuration.nix
@@ -2,6 +2,7 @@
 # Use this to configure your system environment (it replaces /etc/nixos/configuration.nix)
 {
   inputs,
+  outputs,
   lib,
   config,
   pkgs,
@@ -19,7 +20,17 @@
 
     # Import your generated (nixos-generate-config) hardware configuration
     ./hardware-configuration.nix
+
+    # Home Manager NixOS module
+    inputs.home-manager.nixosModules.home-manager
   ];
+
+  home-manager = {
+    useGlobalPkgs = false;
+    useUserPackages = true;
+    extraSpecialArgs = { inherit inputs outputs; };
+    users.nixos = import ../../home-manager/linux;
+  };
 
   nixpkgs = {
     # You can add overlays here

--- a/hosts/vm/configuration.nix
+++ b/hosts/vm/configuration.nix
@@ -81,6 +81,8 @@
   users.users = {
     nixos = {
       isNormalUser = true;
+      # Default password for VM testing. Change it immediately with `passwd`.
+      initialPassword = "nixos";
       openssh.authorizedKeys.keys = [
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC6kPv20dWCWHjJz9hF5PiBQlIgVeHIrIuh3gNJHusnWCJh/SILKEfywE6U+OosJ0ylM/BEl9BOrNlwfof0hz/l6h5xq7v3fZoUKyOvGrZ1tk9/cJx6BPNUwx4E3RBzQ0YZwQKi0C1ojJlSWQfj0ewVne4wuV0MmgaGElxRFxf4zOoE1ONX5ipJ0j/rOv56AguAr1gX/R6SgUEgsFKb/KMD28xXRk16lIGaWqqsnD1ZIO1ixocAwdFCN7ZSpGnYdmQU9r8YGdCRKWXyqQCjsU4r3Vb4QrdZq0zJtUFSS9TMRUyISFClHaRG8fyVENWEMmfTw606wQz46dRUf5VKJL2sOuwofSp3VGyIW8Yft2bW956+MLfVna7grKm9uKHlQMrMXBCz0nBywnDFASubiqpn9nUNYPXykEHJYP2pj5N9lMHpAap9AusMnEFUHPkkDWIJNRlSrRRTHC1yJWmzPCvPGUShQpYgGVvYRlNh56ORbS+2z3Mt5bn//1NFYZvWFKms8JNebIN+9N6sPDNXrTSLn464OC7LDo1t2U00Wwnw/Dm8Tt47nokscBUK8qR8JRLmXR05eCw9gD4DVzWoE4jHOaMlW16qdUzGNb8VMJRfjkF7petSNb8PCYu8VEzo6cT0c7Vgq04p9XsA7i8FZn4jnUppCtL/9U0medGeoB/6gQ=="
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBii9pFXGH+2N8VLWAxZHrVxIc6EJ7I7zKe6PRM/9bUd"


### PR DESCRIPTION
## Summary
- Integrate home-manager as NixOS module for VM, so user config is applied on boot
- Add `make vm/run` to build and start QEMU VM for testing
- Dynamically allocate half of host CPU and memory to VM
- Add default password `nixos` for VM user (for sudo operations)
- Forward SSH to port 2222 for easy access

## Test plan
- [x] Run `make vm/run` on Linux
- [x] Verify home-manager config is applied (zsh, neovim, etc.)
- [x] SSH into VM with `ssh -p 2222 nixos@localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)