### PR TITLE
fix: remove gcc to avoid conflicts with rust toolchain

### DIFF
--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -16,7 +16,7 @@
     username = "nixos";
     homeDirectory = "/home/nixos";
   };
-  home.packages = with pkgs; [ gcc ];
+  home.packages = [ ];
 
   # Add stuff for your user as you see fit:
   # programs.neovim.enable = true;


### PR DESCRIPTION
## Summary
- Remove gcc from home-manager linux packages
- gcc can interfere with rust compilation by providing conflicting libraries and headers
- Ensures a cleaner rust development environment

## Test plan
- [x] Verify rust toolchain works correctly without gcc conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)