### PR TITLE
fix: use mkShellNoCC for dev shell to avoid including C compiler

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
             pkgs = nixpkgs.legacyPackages.${system};
           in
           {
-            default = pkgs.mkShell {
+            default = pkgs.mkShellNoCC {
               packages = [ pkgs.nixfmt-rfc-style ];
             };
           }


### PR DESCRIPTION
## Summary
- Replace `mkShell` with `mkShellNoCC` in the development shell
- Aligns with the recent removal of gcc to prevent conflicts with the rust toolchain

## Test plan
- [x] CI checks pass locally (`nix flake check`, `nixfmt --check`)
- [x] Build dry-run successful for vm, wsl, and home-manager configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)