### PR TITLE
feat: add bootstrap target for first-time home-manager setup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,7 @@ The central configuration file that defines all inputs and outputs.
 
 - **nixosConfigurations**: `vm`, `wsl`
 - **homeConfigurations**: `nixos@linux-x86_64`, `nixos@linux-aarch64`, `henry@darwin-legacy` (x86_64), `henry@darwin` (aarch64)
+- **packages**: `home-manager` — Exposes the home-manager CLI from flake inputs, enabling `nix run '.#home-manager'` for bootstrapping without a prior installation.
 - **overlays**: `unstable-packages`
 - **devShells**: Provides `nixfmt-rfc-style` for all systems
 
@@ -110,6 +111,7 @@ The configuration includes:
 
 Automation commands for building and deployment:
 
+- `make bootstrap`: First-time home-manager setup via `nix run '.#home-manager'` (no prior installation required).
 - `make dry-run`: Validate home-manager configuration.
 - `make switch`: Apply home-manager configuration.
 - `make os/dry-run`: Validate NixOS system configuration.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ _WSL_DISTRO := $(WSL_DISTRO_NAME)
 _HALF_CPUS = $(shell echo $$(( $$(nproc) / 2 )))
 _HALF_MEM = $(shell free -m | awk '/^Mem:/{print int($$2/2)}')
 
-.PHONY: all fmt update dry-run switch os/dry-run os/switch vm/run
+.PHONY: all fmt update bootstrap dry-run switch os/dry-run os/switch vm/run
 
 all: fmt
 
@@ -14,6 +14,25 @@ fmt:
 
 update:
 	nix flake update
+
+bootstrap:
+ifeq ($(_UNAME),Darwin)
+ifeq ($(_ARCH),arm64)
+	nix run '.#home-manager' -- switch --flake '.#henry@darwin'
+else ifeq ($(_ARCH),x86_64)
+	nix run '.#home-manager' -- switch --flake '.#henry@darwin-legacy'
+else
+	$(error Unsupported architecture)
+endif
+else
+ifeq ($(_ARCH),aarch64)
+	nix run '.#home-manager' -- switch --flake '.#nixos@linux-aarch64'
+else ifeq ($(_ARCH),x86_64)
+	nix run '.#home-manager' -- switch --flake '.#nixos@linux-x86_64'
+else
+	$(error Unsupported architecture)
+endif
+endif
 
 dry-run:
 ifeq ($(_UNAME),Darwin)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repository, maintained by henry40408, features configurations managed with 
 
 ## Installation
 
-Install Nix via the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer) (v3.12.2):
+### First-Time Setup
+
+Install Nix via the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer):
 
 ```bash
 sh nix-installer.sh install
@@ -23,18 +25,33 @@ git clone https://github.com/henry40408/nixos-config.git
 cd nixos-config
 ```
 
-To ensure that the NixOS configuration is evaluable, also known as a dry run:
+Bootstrap home-manager (no prior installation required):
 
 ```bash
-make os/dry-run
+make bootstrap
 ```
 
-To deploy the NixOS configuration:
+### Subsequent Updates
 
-(Recommended) Automatically apply the configuration based on the detected environment:
+After the initial bootstrap, use home-manager directly:
 
 ```bash
-make os/switch
+make switch
+```
+
+To validate the configuration before applying (dry run):
+
+```bash
+make dry-run
+```
+
+### NixOS System Configuration
+
+To validate and apply the NixOS system configuration:
+
+```bash
+make os/dry-run   # validate
+make os/switch    # apply
 ```
 
 For WSL:
@@ -61,20 +78,6 @@ This builds and starts a VM with half of host CPU and memory, SSH forwarded to p
 
 ```bash
 ssh -p 2222 nixos@localhost
-```
-
-To ensure that the Home Manager configuration is evaluable, also known as a dry run:
-
-```bash
-make dry-run
-```
-
-To apply the home-manager configuration:
-
-```bash
-home-manager switch --flake .#nixos@all
-# or
-make switch
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Expose `home-manager` CLI via flake `packages` output, enabling `nix run '.#home-manager'` without a prior installation
- Add `make bootstrap` target with platform detection (same logic as `make switch`) for zero-to-configured setup
- Rewrite README installation section into "First-Time Setup" and "Subsequent Updates", removing the incorrect `.#nixos@all` reference
- Update ARCHITECTURE.md with `packages` output and `make bootstrap` docs

## Test plan
- [x] `nix flake show` confirms `packages.<system>.home-manager` appears
- [x] `nix run '.#home-manager' -- --version` outputs `24.11-pre`
- [x] `make bootstrap` on a clean machine (or after removing home-manager from PATH)
- [x] `make switch` still works after bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)