### PR TITLE
feat: upgrade to nixpkgs/home-manager/nixvim 25.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,17 @@ endif
 dry-run:
 ifeq ($(_UNAME),Darwin)
 ifeq ($(_ARCH),arm64)
-	home-manager build --dry-run --flake '.#henry@darwin'
+	home-manager build --dry-run --flake '.#henry@darwin' $(HM_FLAGS)
 else ifeq ($(_ARCH),x86_64)
-	home-manager build --dry-run --flake '.#henry@darwin-legacy'
+	home-manager build --dry-run --flake '.#henry@darwin-legacy' $(HM_FLAGS)
 else
 	$(error Unsupported architecture)
 endif
 else
 ifeq ($(_ARCH),aarch64)
-	home-manager build --dry-run --flake '.#nixos@linux-aarch64'
+	home-manager build --dry-run --flake '.#nixos@linux-aarch64' $(HM_FLAGS)
 else ifeq ($(_ARCH),x86_64)
-	home-manager build --dry-run --flake '.#nixos@linux-x86_64'
+	home-manager build --dry-run --flake '.#nixos@linux-x86_64' $(HM_FLAGS)
 else
 	$(error Unsupported architecture)
 endif
@@ -56,17 +56,17 @@ endif
 switch:
 ifeq ($(_UNAME),Darwin)
 ifeq ($(_ARCH),arm64)
-	home-manager switch --flake '.#henry@darwin'
+	home-manager switch --flake '.#henry@darwin' $(HM_FLAGS)
 else ifeq ($(_ARCH),x86_64)
-	home-manager switch --flake '.#henry@darwin-legacy'
+	home-manager switch --flake '.#henry@darwin-legacy' $(HM_FLAGS)
 else
 	$(error Unsupported architecture)
 endif
 else
 ifeq ($(_ARCH),aarch64)
-	home-manager switch --flake '.#nixos@linux-aarch64'
+	home-manager switch --flake '.#nixos@linux-aarch64' $(HM_FLAGS)
 else ifeq ($(_ARCH),x86_64)
-	home-manager switch --flake '.#nixos@linux-x86_64'
+	home-manager switch --flake '.#nixos@linux-x86_64' $(HM_FLAGS)
 else
 	$(error Unsupported architecture)
 endif

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -37,20 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "revCount": 69,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -59,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -90,91 +55,21 @@
         "type": "github"
       }
     },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "nixvim",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749636823,
-        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1770260404,
+        "narHash": "sha256-3iVX1+7YUIt23hBx1WZsUllhbmP2EnXrV8tCRbLxHc8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "0d782ee42c86b196acff08acfbf41bb7d13eed5b",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -193,39 +88,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1748294338,
-        "narHash": "sha256-FVO01jdmUNArzBS7NmaktLdGA5qA3lUMJ4B7a05Iynw=",
+        "lastModified": 1754860581,
+        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "cc5f390f7caf265461d4aab37e98d2292ebbdb85",
+        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.8",
+        "ref": "v0.1.1",
         "repo": "ixx",
-        "type": "github"
-      }
-    },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1743127615,
-        "narHash": "sha256-+sMGqywrSr50BGMLMeY789mSrzjkoxZiu61eWjYS/8o=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "fc843893cecc1838a59713ee3e50e9e7edc6207c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "ref": "nix-darwin-24.11",
-        "repo": "nix-darwin",
         "type": "github"
       }
     },
@@ -250,16 +123,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746055187,
-        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
+        "lastModified": 1770136044,
+        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
+        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -298,59 +171,54 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1750709846,
-        "narHash": "sha256-vWXzyQn0UIPC9TjimWjOhwlJ4lYx4v4ii9inmLwByJk=",
+        "lastModified": 1771254358,
+        "narHash": "sha256-0Ckp23ZPb60TV1Up0y+QzdTwk6sbMju3tEKSYy9MRGs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2e4f7e7d3376cdd7030c9456190339417567db03",
+        "rev": "7e8d4997c66bb68a40f894cd6b7a8df4ed6fd4a7",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11-small",
+        "ref": "nixos-25.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1750330365,
-        "narHash": "sha256-hJ7XMNVsTnnbV2NPmStCC07gvv5l2x7+Skb7hyUzazg=",
+        "lastModified": 1768323494,
+        "narHash": "sha256-yBXJLE6WCtrGo7LKiB6NOt6nisBEEkguC/lq/rP3zRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d883b6213afa179b58ba8bace834f1419707d0ad",
+        "rev": "2c3e5ec5df46d3aeee2a1da0bfedd74e21f4bf3a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixvim": {
       "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts",
-        "git-hooks": "git-hooks",
-        "home-manager": "home-manager_2",
-        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_4",
         "nuschtosSearch": "nuschtosSearch",
-        "treefmt-nix": "treefmt-nix"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750512588,
-        "narHash": "sha256-dVffwpFhdLFIceioQTaPD9427TqZXWD7YRI1/QoWdBU=",
+        "lastModified": 1769049374,
+        "narHash": "sha256-h0Os2qqNyycDY1FyZgtbn28VF1ySP74/n0f+LDd8j+w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ea038b062ba2c73a38442264302c3f93dd62ba96",
+        "rev": "b8f76bf5751835647538ef8784e4e6ee8deb8f95",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixvim",
         "type": "github"
       }
@@ -365,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749730855,
-        "narHash": "sha256-L3x2nSlFkXkM6tQPLJP3oCBMIsRifhIDPMQQdHO5xWo=",
+        "lastModified": 1768249818,
+        "narHash": "sha256-ANfn5OqIxq3HONPIXZ6zuI5sLzX1sS+2qcf/Pa0kQEc=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "8dfe5879dd009ff4742b668d9c699bc4b9761742",
+        "rev": "b6f77b88e9009bfde28e2130e218e5123dc66796",
         "type": "github"
       },
       "original": {
@@ -402,24 +270,18 @@
         "type": "github"
       }
     },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+    "systems_2": {
       "locked": {
-        "lastModified": 1749194973,
-        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -137,22 +137,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1750784563,
-        "narHash": "sha256-b+h6vDusoS8vqJQY/uUjiIaZRM3q9i4c38CqonwWm+4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a6f85bdd8e1a16c78eb2b2808542fc939bce41ec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1770197578,
@@ -251,7 +235,6 @@
         "home-manager": "home-manager",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,6 @@
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
 
-    # Nixpkgs (next)
-    # nixpkgs-next.url = "github:nixos/nixpkgs/nixos-25.05-small";
-
-    # Nixpkgs (unstable)
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/master";
-
     # Home manager
     home-manager.url = "github:nix-community/home-manager/release-25.11";
 
@@ -39,7 +33,7 @@
     in
     {
       # Your custom packages and modifications, exported as overlays
-      overlays = import ./overlays { inherit inputs; };
+      overlays = import ./overlays { };
 
       # NixOS configuration entrypoint
       # Available through 'nixos-rebuild --flake .#your-hostname'

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11-small";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
 
     # Nixpkgs (next)
     # nixpkgs-next.url = "github:nixos/nixpkgs/nixos-25.05-small";
@@ -12,13 +12,13 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/master";
 
     # Home manager
-    home-manager.url = "github:nix-community/home-manager/release-24.11";
+    home-manager.url = "github:nix-community/home-manager/release-25.11";
 
     # NixOS WSL
     nixos-wsl.url = "github:nix-community/nixos-wsl";
 
     # nixvim
-    nixvim.url = "github:nix-community/nixvim/nixos-24.11";
+    nixvim.url = "github:nix-community/nixvim/nixos-25.11";
   };
 
   outputs =

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -2,37 +2,43 @@
 {
   imports = [ ./nixvim ];
 
-  home.packages = with pkgs; [
-    fd
-    fnm
-    git-extras
-    gnumake
-    gping
-    nixfmt-rfc-style
-    procs
-    spacer
-    xh
-    zsh-autopair
-    zsh-completions
-    zsh-fzf-tab
-    zsh-powerlevel10k
-    zsh-you-should-use
+  home.packages =
+    with pkgs;
+    [
+      fd
+      fnm
+      git-extras
+      gnumake
+      gping
+      nixfmt-rfc-style
+      procs
+      spacer
+      xh
+      zsh-autopair
+      zsh-completions
+      zsh-fzf-tab
+      zsh-powerlevel10k
+      zsh-you-should-use
 
-    (writeShellScriptBin "clipboard-copy" (
-      if stdenv.isDarwin then ''
-        exec pbcopy "$@"
-      '' else ''
-        if [ -n "$WAYLAND_DISPLAY" ]; then
-          exec ${wl-clipboard}/bin/wl-copy "$@"
+      (writeShellScriptBin "clipboard-copy" (
+        if stdenv.isDarwin then
+          ''
+            exec pbcopy "$@"
+          ''
         else
-          exec ${xclip}/bin/xclip -selection clipboard "$@"
-        fi
-      ''
-    ))
-  ] ++ lib.optionals stdenv.isLinux [
-    wl-clipboard
-    xclip
-  ];
+          ''
+            if [ -n "$WAYLAND_DISPLAY" ]; then
+              exec ${wl-clipboard}/bin/wl-copy "$@"
+            else
+              exec ${xclip}/bin/xclip -selection clipboard "$@"
+            fi
+          ''
+      ))
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      wl-clipboard
+      xclip
+    ];
 
   home.file.".p10k.zsh".text = (builtins.readFile ./zsh/p10k.zsh);
   home.file."Develop/.envrc".text = (builtins.readFile ./envrc);

--- a/home-manager/common/nixpkgs.nix
+++ b/home-manager/common/nixpkgs.nix
@@ -1,7 +1,10 @@
 { outputs, ... }:
 {
   nixpkgs = {
-    overlays = [ outputs.overlays.unstable-packages ];
+    overlays = [
+      outputs.overlays.unstable-packages
+      outputs.overlays.fix-inetutils
+    ];
     config = {
       allowUnfree = true;
       # Workaround for https://github.com/nix-community/home-manager/issues/2942

--- a/home-manager/common/nixpkgs.nix
+++ b/home-manager/common/nixpkgs.nix
@@ -2,7 +2,6 @@
 {
   nixpkgs = {
     overlays = [
-      outputs.overlays.unstable-packages
       outputs.overlays.fix-inetutils
     ];
     config = {

--- a/home-manager/common/nixvim/lsp.nix
+++ b/home-manager/common/nixvim/lsp.nix
@@ -101,7 +101,7 @@
           };
         };
       };
-      servers.volar.enable = true;
+      servers.vue_ls.enable = true;
     };
     plugins.luasnip.enable = true;
     plugins.none-ls.enable = true;

--- a/home-manager/common/nixvim/lsp.nix
+++ b/home-manager/common/nixvim/lsp.nix
@@ -89,9 +89,7 @@
       servers.ruff.enable = true;
       servers.pyright.enable = true;
       servers.taplo.enable = true;
-      # ts_ls is disabled because its bundled nodejs-slim version mismatches
-      # with the nodejs in extraPackages, causing runtime conflicts.
-      # servers.ts_ls.enable = true;
+      servers.ts_ls.enable = true;
       servers.rust_analyzer = {
         enable = true;
         package = null; # rust-analyzer should be managed by rustup

--- a/home-manager/darwin/default.nix
+++ b/home-manager/darwin/default.nix
@@ -16,7 +16,6 @@
   };
   home.packages = with pkgs; [
     automake
-    aria
     mas
     pkg-config
   ];

--- a/home-manager/darwin/default.nix
+++ b/home-manager/darwin/default.nix
@@ -5,7 +5,7 @@
 }:
 {
   imports = [
-    inputs.nixvim.homeManagerModules.nixvim
+    inputs.nixvim.homeModules.nixvim
     ../common
     ../common/nixpkgs.nix
   ];

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -7,7 +7,7 @@
 }:
 {
   imports = [
-    inputs.nixvim.homeManagerModules.nixvim
+    inputs.nixvim.homeModules.nixvim
     ../common
     ../common/nixpkgs.nix
   ];

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -11,21 +11,26 @@
 # It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
 # extension. Note: Most shells limit `local` to 1 var per line, contra bash.
 
-# This script is based off https://github.com/rust-lang/rustup/blob/f8d7b3baba7a63237cb2b82ef49a68a37dd0633c/rustup-init.sh
+# This script is based off https://github.com/rust-lang/rustup/blob/2d429e8e172d5854b6dd7244ecbb0dc3da88a678/rustup-init.sh
 
-if [ "$KSH_VERSION" = 'Version JM 93t+ 2010-03-05' ]; then
-    # The version of ksh93 that ships with many illumos systems does not
-    # support the "local" extension.  Print a message rather than fail in
-    # subtle ways later on:
-    echo 'nix-installer does not work with this ksh93 version; please try bash!' >&2
-    exit 1
-fi
+# Some versions of ksh have no `local` keyword. Alias it to `typeset`, but
+# beware this makes variables global with f()-style function syntax in ksh93.
+# mksh has this alias by default.
+has_local() {
+    # shellcheck disable=SC2034  # deliberately unused
+    local _has_local
+}
 
+has_local 2>/dev/null || alias local=typeset
+
+is_zsh() {
+    [ -n "${ZSH_VERSION-}" ]
+}
 
 set -u
 
 # If NIX_INSTALLER_FORCE_ALLOW_HTTP is unset or empty, default it.
-NIX_INSTALLER_BINARY_ROOT="${NIX_INSTALLER_BINARY_ROOT:-https://install.determinate.systems/nix/tag/v0.27.0}"
+NIX_INSTALLER_BINARY_ROOT="${NIX_INSTALLER_BINARY_ROOT:-https://install.determinate.systems/nix/tag/v3.12.2}"
 
 main() {
     downloader --check
@@ -84,18 +89,14 @@ main() {
         need_tty=no
     fi
 
-    if $_ansi_escapes_are_valid; then
-        printf "\33[1minfo:\33[0m downloading installer \33[4m%s\33[0m\n" "$_url" 1>&2
-    else
-        printf 'info: downloading installer (%s)\n' "$_url" 1>&2
-    fi
+    say 'downloading installer'
 
     ensure mkdir -p "$_dir"
     ensure downloader "$_url" "$_file" "$_arch"
     ensure chmod u+x "$_file"
     if [ ! -x "$_file" ]; then
-        printf '%s\n' "Cannot execute $_file (likely because of mounting /tmp as noexec)." 1>&2
-        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./nix-installer${_ext}." 1>&2
+        err "Cannot execute $_file (likely because of mounting /tmp as noexec)." 1>&2
+        err "Please copy the file to a location where you can execute binaries and run ./nix-installer${_ext}." 1>&2
         exit 1
     fi
 
@@ -106,6 +107,7 @@ main() {
         # to explicitly connect /dev/tty to the installer's stdin.
         if [ ! -t 1 ]; then
             err "Unable to run interactively. Run with --no-confirm to accept defaults, --help for additional options"
+            exit 1;
         fi
 
         ignore "$_file" "$@" < /dev/tty
@@ -121,12 +123,23 @@ main() {
     return "$_retval"
 }
 
-check_proc() {
-    # Check for /proc by looking for the /proc/self/exe link
+get_current_exe() {
+    # Returns the executable used for system architecture detection
     # This is only run on Linux
-    if ! test -L /proc/self/exe ; then
-        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    local _current_exe
+    if test -L /proc/self/exe ; then
+        _current_exe=/proc/self/exe
+    else
+        warn "Unable to find /proc/self/exe. System architecture detection might be inaccurate."
+        if test -n "$SHELL" ; then
+            _current_exe=$SHELL
+        else
+            need_cmd /bin/sh
+            _current_exe=/bin/sh
+        fi
+        warn "Falling back to $_current_exe."
     fi
+    echo "$_current_exe"
 }
 
 get_architecture() {
@@ -137,9 +150,6 @@ get_architecture() {
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
-        fi
-        if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
         fi
     fi
 
@@ -155,7 +165,7 @@ get_architecture() {
             # See: <https://support.apple.com/en-us/HT208436>
 
             # Avoid `sysctl: unknown oid` stderr output and/or non-zero exit code.
-            if sysctl hw.optional.x86_64 2> /dev/null || true | grep -q ': 1'; then
+            if (sysctl hw.optional.x86_64 2> /dev/null || true) | grep -q ': 1'; then
                 _cputype=x86_64
             fi
         elif [ "$_cputype" = x86_64 ]; then
@@ -164,7 +174,7 @@ get_architecture() {
             # Rosetta 2 is built exclusively for x86-64 and cannot run i386 binaries.
 
             # Avoid `sysctl: unknown oid` stderr output and/or non-zero exit code.
-            if sysctl hw.optional.arm64 2> /dev/null || true | grep -q ': 1'; then
+            if (sysctl hw.optional.arm64 2> /dev/null || true) | grep -q ': 1'; then
                 _cputype=arm64
             fi
         fi
@@ -188,9 +198,10 @@ get_architecture() {
         fi
     fi
 
+    local _current_exe
     case "$_ostype" in
         Linux)
-            check_proc
+            _current_exe=$(get_current_exe)
             _ostype=linux
             ;;
 
@@ -200,6 +211,7 @@ get_architecture() {
 
         *)
             err "unrecognized OS type: $_ostype"
+            exit 1
             ;;
 
     esac
@@ -224,18 +236,32 @@ get_architecture() {
     RETVAL="$_arch"
 }
 
-say() {
-    printf 'nix-installer: %s\n' "$1"
+__print() {
+    if $_ansi_escapes_are_valid; then
+        printf '\33[1m%s:\33[0m %s\n' "$1" "$2" >&2
+    else
+        printf '%s: %s\n' "$1" "$2" >&2
+    fi
 }
 
+warn() {
+    __print 'warn' "$1" >&2
+}
+
+say() {
+    __print 'info' "$1" >&2
+}
+
+# NOTE: you are required to exit yourself
+# we don't do it here because of multiline errors
 err() {
-    say "$1" >&2
-    exit 1
+    __print 'error' "$1" >&2
 }
 
 need_cmd() {
     if ! check_cmd "$1"; then
         err "need '$1' (command not found)"
+        exit 1
     fi
 }
 
@@ -244,14 +270,20 @@ check_cmd() {
 }
 
 assert_nz() {
-    if [ -z "$1" ]; then err "assert_nz $2"; fi
+    if [ -z "$1" ]; then
+        err "assert_nz $2"
+        exit 1
+    fi
 }
 
 # Run a command that should never fail. If the command fails execution
 # will immediately terminate with an error showing the failing
 # command.
 ensure() {
-    if ! "$@"; then err "command failed: $*"; fi
+    if ! "$@"; then
+        err "command failed: $*"
+        exit 1
+    fi
 }
 
 # This is just for indicating that commands' results are being
@@ -264,13 +296,31 @@ ignore() {
 # This wraps curl or wget. Try curl first, if not installed,
 # use wget instead.
 downloader() {
+    # zsh does not split words by default, Required for curl retry arguments below.
+    is_zsh && setopt local_options shwordsplit
+
     local _dld
     local _ciphersuites
     local _err
     local _status
     local _retry
     if check_cmd curl; then
-        _dld=curl
+        # Check if we have a broken snap curl
+        # https://github.com/boukendesho/curl-snap/issues/1
+        _curl_path=$(command -v curl)
+        if echo "$_curl_path" | grep "/snap/" > /dev/null 2>&1; then
+            if check_cmd wget; then
+                _dld=wget
+            else
+                err "curl installed with snap cannot be used to install Rust"
+                err "due to missing permissions. Please uninstall it and"
+                err "reinstall curl with a different package manager (e.g., apt)."
+                err "See https://github.com/boukendesho/curl-snap/issues/1"
+                exit 1
+            fi
+        else
+            _dld=curl
+        fi
     elif check_cmd wget; then
         _dld=wget
     else
@@ -285,37 +335,33 @@ downloader() {
         get_ciphersuites_for_curl
         _ciphersuites="$RETVAL"
         if [ -n "$_ciphersuites" ]; then
-            if [ -n "${NIX_INSTALLER_FORCE_ALLOW_HTTP-}" ]; then
-                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
-                _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
-            else
-                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
-                _err=$(curl $_retry --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
-            fi
+            # shellcheck disable=SC2086
+            _err=$(curl $_retry --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             _status=$?
         else
-            echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
+            warn "Not enforcing strong cipher suites for TLS, this is potentially less secure"
             if ! check_help_for "$3" curl --proto --tlsv1.2; then
-                echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
-                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
+                warn "Not enforcing TLS v1.2, this is potentially less secure"
+                # shellcheck disable=SC2086
                 _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             else
-                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
+                # shellcheck disable=SC2086
                 _err=$(curl $_retry --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             fi
         fi
         if [ -n "$_err" ]; then
-            echo "$_err" >&2
+            warn "$_err"
             if echo "$_err" | grep -q 404$; then
                 err "installer for platform '$3' not found, this may be unsupported"
+                exit 1
             fi
         fi
         return $_status
     elif [ "$_dld" = wget ]; then
         if [ "$(wget -V 2>&1|head -2|tail -1|cut -f1 -d" ")" = "BusyBox" ]; then
-            echo "Warning: using the BusyBox version of wget.  Not enforcing strong cipher suites for TLS or TLS v1.2, this is potentially less secure"
+            warn "using the BusyBox version of wget.  Not enforcing strong cipher suites for TLS or TLS v1.2, this is potentially less secure"
             _err=$(wget "$1" -O "$2" 2>&1)
             _status=$?
         else
@@ -325,9 +371,9 @@ downloader() {
                 _err=$(wget --https-only --secure-protocol=TLSv1_2 --ciphers "$_ciphersuites" "$1" -O "$2" 2>&1)
                 _status=$?
             else
-                echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
+                warn "Not enforcing strong cipher suites for TLS, this is potentially less secure"
                 if ! check_help_for "$3" wget --https-only --secure-protocol; then
-                    echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
+                    warn "Not enforcing TLS v1.2, this is potentially less secure"
                     _err=$(wget "$1" -O "$2" 2>&1)
                     _status=$?
                 else
@@ -337,14 +383,16 @@ downloader() {
             fi
         fi
         if [ -n "$_err" ]; then
-            echo "$_err" >&2
+            warn "$_err"
             if echo "$_err" | grep -q ' 404 Not Found$'; then
                 err "installer for platform '$3' not found, this may be unsupported"
+                exit 1
             fi
         fi
         return $_status
     else
         err "Unknown downloader"   # should not reach here
+        exit 1
     fi
 }
 
@@ -358,7 +406,7 @@ check_help_for() {
     shift
 
     local _category
-    if "$_cmd" --help | grep -q 'For all options use the manual or "--help all".'; then
+    if "$_cmd" --help | grep -q '"--help all"'; then
       _category="all"
     else
       _category=""
@@ -368,24 +416,27 @@ check_help_for() {
 
         *darwin*)
         if check_cmd sw_vers; then
-            case $(sw_vers -productVersion) in
-                10.*)
+            local _os_version
+            local _os_major
+            _os_version=$(sw_vers -productVersion)
+            _os_major=$(echo "$_os_version" | cut -d. -f1)
+            case $_os_major in
+                10)
                     # If we're running on macOS, older than 10.13, then we always
                     # fail to find these options to force fallback
-                    if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
+                    if [ "$(echo "$_os_version" | cut -d. -f2)" -lt 13 ]; then
                         # Older than 10.13
-                        echo "Warning: Detected macOS platform older than 10.13"
+                        warn "Detected macOS platform older than 10.13"
                         return 1
                     fi
                     ;;
-                11.*)
-                    # We assume Big Sur will be OK for now
-                    ;;
                 *)
-                    # Unknown product version, warn and continue
-                    echo "Warning: Detected unknown macOS major version: $(sw_vers -productVersion)"
-                    echo "Warning TLS capabilities detection may fail"
-                    ;;
+                    if ! { [ "$_os_major" -eq "$_os_major" ] 2>/dev/null && [ "$_os_major" -ge 11 ]; }; then
+                        # Unknown product version, warn and continue
+                        warn "Detected unknown macOS major version: $_os_version"
+                        warn "TLS capabilities detection may fail"
+                    fi
+                    ;; # We assume that macOS v11+ will always be okay.
             esac
         fi
         ;;
@@ -393,7 +444,7 @@ check_help_for() {
     esac
 
     for _arg in "$@"; do
-        if ! "$_cmd" --help $_category | grep -q -- "$_arg"; then
+        if ! "$_cmd" --help "$_category" | grep -q -- "$_arg"; then
             return 1
         fi
     done
@@ -402,15 +453,33 @@ check_help_for() {
 }
 
 # Check if curl supports the --retry flag, then pass it to the curl invocation.
+# Note that --speed-limit and --speed-time were in the very first commit of curl.
+# So this should be pretty much ubiquitously safe.
 check_curl_for_retry_support() {
-  local _retry_supported=""
+  local _retry_part=""
+  local _continue_part=""
+  local _speed_limit_part=""
+
   # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
   if check_help_for "notspecified" "curl" "--retry"; then
-    _retry_supported="--retry 3"
+      _retry_part="--retry 3"
+
+      if check_help_for "notspecified" "curl" "--continue-at"; then
+          # "-C -" tells curl to automatically find where to resume the download when retrying.
+          _continue_part="--continue-at -"
+      fi
+
+      if check_help_for "notspecified" "curl" "--speed-limit" \
+          && check_help_for "notspecified" "curl" "--speed-time"; then
+        # 250000 is approximately 20% of the bandwidth of typical DSL
+        # these limits mean users below these limits will see failures.
+        _speed_limit_part="--speed-limit 250000 --speed-time 15"
+      fi
   fi
 
-  RETVAL="$_retry_supported"
+  RETVAL="$_retry_part $_continue_part $_speed_limit_part"
 }
+
 
 # Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites
 # if support by local tools is detected. Detection currently supports these curl backends:

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -6,4 +6,22 @@
       config.allowUnfree = true;
     };
   };
+
+  # Workaround for https://github.com/NixOS/nixpkgs/issues/488689
+  # gnulib's error() macro passes dgettext() results as format strings,
+  # triggering -Werror,-Wformat-security in openat-die.c
+  # Solution from https://github.com/wimpysworld/nix-config/commit/4248e93
+  fix-inetutils = _final: prev: {
+    inetutils = prev.inetutils.overrideAttrs (
+      old:
+      prev.lib.optionalAttrs prev.stdenv.isDarwin {
+        env = (old.env or { }) // {
+          NIX_CFLAGS_COMPILE = toString [
+            (old.env.NIX_CFLAGS_COMPILE or "")
+            "-Wno-format-security"
+          ];
+        };
+      }
+    );
+  };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,12 +1,5 @@
-{ inputs, ... }:
+{ ... }:
 {
-  unstable-packages = final: _prev: {
-    unstable = import inputs.nixpkgs-unstable {
-      system = final.system;
-      config.allowUnfree = true;
-    };
-  };
-
   # Workaround for https://github.com/NixOS/nixpkgs/issues/488689
   # gnulib's error() macro passes dgettext() results as format strings,
   # triggering -Werror,-Wformat-security in openat-die.c


### PR DESCRIPTION
## Summary
- Upgrade nixpkgs, home-manager, and nixvim from 24.11 to 25.11
- Migrate deprecated home-manager options (git, zsh, delta, nixvim module path)
- Add overlay to fix inetutils build failure on Darwin ([NixOS/nixpkgs#488689](https://github.com/NixOS/nixpkgs/issues/488689))
- Re-enable ts_ls LSP now that nodejs conflict is resolved in 25.11
- Update Determinate Nix Installer script to v3.12.2
- Add `HM_FLAGS` support to Makefile for passing flags like `-L`
- Remove aria from Darwin packages

## Test plan
- [x] `make dry-run` passes without errors or deprecation warnings
- [x] `make switch` applies successfully
- [x] Verify nixvim plugins and LSP servers work correctly
- [x] Verify zsh shell initializes properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)