### PR TITLE
feat(ghostty): enable ssh-env and ssh-terminfo integration

### DIFF
--- a/home-manager/common/ghostty/default.nix
+++ b/home-manager/common/ghostty/default.nix
@@ -28,6 +28,10 @@
       window-padding-x = 8;
       window-padding-y = 8;
       confirm-close-surface = false;
+      # Keep Ghostty's defaults (cursor, sudo, title) and add SSH helpers:
+      # ssh-env forwards COLORTERM/TERM_PROGRAM* and sets TERM=xterm-256color;
+      # ssh-terminfo installs Ghostty's terminfo on the remote on first connect.
+      shell-integration-features = "cursor,sudo,title,ssh-env,ssh-terminfo";
       keybind = [
         "cmd+shift+,=reload_config"
         "ctrl+shift+,=reload_config"


### PR DESCRIPTION
## Summary
- Add `shell-integration-features = "cursor,sudo,title,ssh-env,ssh-terminfo"` to the Ghostty config, preserving the three defaults and enabling Ghostty's SSH helpers.
- `ssh-env` forwards `COLORTERM`, `TERM_PROGRAM`, and `TERM_PROGRAM_VERSION` and sets `TERM=xterm-256color` on remote sessions.
- `ssh-terminfo` installs Ghostty's terminfo on the remote host on first connect and caches the result.

## Test plan
- [ ] Rebuild home-manager and reload the Ghostty config (`cmd/ctrl+shift+,`).
- [ ] `ghostty +show-config | grep shell-integration-features` reports all five features.
- [ ] SSH to a remote host and verify `echo "$COLORTERM $TERM_PROGRAM $TERM"` reports truecolor/ghostty/xterm-256color.
- [ ] On a fresh remote host, confirm the Ghostty terminfo is installed after the first connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)