### PR TITLE
fix(home-manager/linux): switch pinentry to gnome3 for ghostty

### DIFF
--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -36,7 +36,7 @@
     defaultCacheTtl = 86400; # 1 day
     enableSshSupport = true;
     maxCacheTtl = 604800; # 1 week
-    pinentry.package = pkgs.pinentry-curses;
+    pinentry.package = pkgs.pinentry-gnome3;
   };
   services.syncthing.enable = true;
 }


### PR DESCRIPTION
## Summary

- `pinentry-curses` fails with `Screen or window too small` inside ghostty when the terminal window does not meet its minimum size, blocking GPG signing and SSH key unlocking.
- Switch to `pinentry-gnome3`, which opens a separate GUI dialog and is unaffected by terminal dimensions. This also matches the GNOME/Wayland desktop environment used on the Linux host.

## Test plan

- [x] `make dry-run` builds successfully
- [x] `make switch` applies the new generation
- [x] `~/.gnupg/gpg-agent.conf` now points to `pinentry-gnome3-1.3.2`
- [x] `gpg-connect-agent reloadagent /bye` returns `OK`
- [ ] Trigger a signing operation inside ghostty (e.g. `echo test | gpg --clearsign`) and confirm the GNOME pinentry dialog appears