### PR TITLE
feat(home-manager): add nix-index-database for pre-built nix-index db

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,6 +15,7 @@ The central configuration file that defines all inputs and outputs.
 | `home-manager` | nix-community (25.11) | User environment management |
 | `nixos-wsl` | nix-community | WSL support |
 | `nixvim` | nix-community (25.11) | Neovim configuration framework |
+| `nix-index-database` | nix-community | Weekly pre-built nix-index database for `nix-locate` and `command-not-found` |
 
 ### Outputs
 

--- a/flake.lock
+++ b/flake.lock
@@ -102,6 +102,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776829403,
+        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -249,6 +269,7 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "nix-index-database": "nix-index-database",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,10 @@
 
     # nixvim
     nixvim.url = "github:nix-community/nixvim/nixos-25.11";
+
+    # nix-index database (pre-built nix-index database for command-not-found / nix-locate)
+    nix-index-database.url = "github:nix-community/nix-index-database";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -1,6 +1,12 @@
-{ pkgs, lib, ... }:
+{
+  inputs,
+  pkgs,
+  lib,
+  ...
+}:
 {
   imports = [
+    inputs.nix-index-database.homeModules.nix-index
     ./ghostty
     ./nixvim
   ];


### PR DESCRIPTION
## Summary
- Add `nix-index-database` flake input (`inputs.nixpkgs.follows = "nixpkgs"`) and import `homeModules.nix-index` from `home-manager/common/default.nix`.
- The existing `programs.nix-index` wrapper now uses the weekly pre-built database from [nix-community/nix-index-database](https://github.com/nix-community/nix-index-database), so `nix-locate` and fish command-not-found integration work on fresh setups without running `nix-index` locally.
- Update `ARCHITECTURE.md` inputs table.

## Test plan
- [x] `nix flake lock` adds the new input cleanly
- [x] `nix build --dry-run .#homeConfigurations."nixos@linux-x86_64".activationPackage` evaluates and resolves `nix-index-with-full-db`
- [x] `nix eval` for `homeConfigurations."henry@darwin"`, `nixosConfigurations.vm`, `nixosConfigurations.wsl` all succeed
- [x] `nixfmt-rfc-style --check` on changed Nix files
- [ ] `make switch` on a Linux host and confirm `nix-locate <pattern>` works without a manual `nix-index` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)