### PR TITLE
chore(flake): remove unused nixpkgs-unstable overlay and input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,22 +157,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1773734432,
@@ -272,7 +256,6 @@
         "nix-index-database": "nix-index-database",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     # Home manager
     home-manager.url = "github:nix-community/home-manager/release-25.11";
@@ -24,7 +23,6 @@
     {
       self,
       nixpkgs,
-      nixpkgs-unstable,
       home-manager,
       ...
     }@inputs:

--- a/home-manager/common/nixpkgs.nix
+++ b/home-manager/common/nixpkgs.nix
@@ -2,7 +2,6 @@
 {
   nixpkgs = {
     overlays = [
-      outputs.overlays.unstable-packages
       outputs.overlays.fix-inetutils
     ];
     config = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,16 +1,5 @@
-{ inputs, ... }:
-let
-  inherit (inputs) nixpkgs-unstable;
-in
+{ ... }:
 {
-  # Overlay to use packages from nixpkgs unstable channel
-  unstable-packages = final: _prev: {
-    unstable = import nixpkgs-unstable {
-      system = final.stdenv.hostPlatform.system;
-      config.allowUnfree = true;
-    };
-  };
-
   # Workaround for https://github.com/NixOS/nixpkgs/issues/488689
   # gnulib's error() macro passes dgettext() results as format strings,
   # triggering -Werror,-Wformat-security in openat-die.c


### PR DESCRIPTION
## Summary

The `unstable-packages` overlay exposed `pkgs.unstable.*`, but it was **never referenced anywhere** in the config (a repo-wide grep for `pkgs.unstable.` returns zero uses). Keeping it had only downsides:

- It pulled a **second full nixpkgs source** into `flake.lock` and the store purely as dead weight — wasteful on disk/bandwidth, which matters most on the aarch64 Raspberry Pi target.
- It was a latent trap: a future `pkgs.unstable.foo` would force a **dual stable + unstable evaluation** and likely **from-source builds** (unstable rarely has aarch64 cache hits) — painful on a Pi.

This PR removes:
- the `nixpkgs-unstable` flake input (and its destructured arg in `outputs`)
- the `unstable-packages` overlay and its now-unused `inputs` binding in `overlays/default.nix`
- its entry in home-manager's overlays list (`home-manager/common/nixpkgs.nix`)

`fix-inetutils` is retained. `flake.lock` drops the `nixpkgs-unstable` node automatically.

## Verification

- `nix flake check --no-build` passes
- `nix eval .#homeConfigurations."nixos@linux-aarch64".activationPackage.drvPath` evaluates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)