### PR TITLE
chore: remove unused nixpkgs-unstable input and overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,22 +122,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1776481463,
@@ -220,7 +204,6 @@
         "home-manager": "home-manager",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     # Home manager
     home-manager.url = "github:nix-community/home-manager/release-25.11";
@@ -21,7 +20,6 @@
     {
       self,
       nixpkgs,
-      nixpkgs-unstable,
       home-manager,
       ...
     }@inputs:

--- a/home-manager/common/nixpkgs.nix
+++ b/home-manager/common/nixpkgs.nix
@@ -2,7 +2,6 @@
 {
   nixpkgs = {
     overlays = [
-      outputs.overlays.unstable-packages
       outputs.overlays.fix-inetutils
     ];
     config = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,16 +1,5 @@
-{ inputs, ... }:
-let
-  inherit (inputs) nixpkgs-unstable;
-in
+{ ... }:
 {
-  # Overlay to use packages from nixpkgs unstable channel
-  unstable-packages = final: _prev: {
-    unstable = import nixpkgs-unstable {
-      system = final.stdenv.hostPlatform.system;
-      config.allowUnfree = true;
-    };
-  };
-
   # Workaround for https://github.com/NixOS/nixpkgs/issues/488689
   # gnulib's error() macro passes dgettext() results as format strings,
   # triggering -Werror,-Wformat-security in openat-die.c


### PR DESCRIPTION
## Summary

The `unstable-packages` overlay exposed `pkgs.unstable` but no package in the configuration consumed it. Drop the unused dependency.

## Changes

- Remove the `nixpkgs-unstable` flake input (and its `outputs` destructure)
- Remove the `unstable-packages` overlay from `overlays/default.nix`
- Remove the overlay registration from `home-manager/common/nixpkgs.nix`

## Verification

- `nixfmt --check .` passes
- `nix flake check` passes; the only remaining overlay is `fix-inetutils`
- No `unstable` references remain in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)