### PR TITLE
docs: fix first-time setup order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ This repository, maintained by henry40408, features configurations managed with 
 
 ### First-Time Setup
 
-Install Nix via the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer):
-
-```bash
-sh nix-installer.sh install
-```
-
 Clone this repository:
 
 ```bash
@@ -25,7 +19,13 @@ git clone https://github.com/henry40408/nixos-config.git
 cd nixos-config
 ```
 
-Bootstrap home-manager (no prior installation required):
+Install Nix via the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer):
+
+```bash
+sh nix-installer.sh install
+```
+
+Bootstrap home-manager (`nix run` fetches Home Manager on demand, so no separate Home Manager installation is required):
 
 ```bash
 make bootstrap


### PR DESCRIPTION
## Summary

- Reorder the **First-Time Setup** steps so the repository is cloned **before** running `sh nix-installer.sh install`. The installer script lives inside this repo, so the previous order referenced a file that did not exist yet at that point.
- Clarify the `make bootstrap` note: `nix run` fetches Home Manager on demand, so no *separate Home Manager* install is needed — but Nix itself must still be installed first. The old "(no prior installation required)" wording was easy to misread as "nothing needs installing".

## Notes

Documentation-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)