### PR TITLE
chore: remove mise from home-manager config

### DIFF
--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -335,7 +335,6 @@
       };
     };
   };
-  programs.mise.enable = true;
   programs.ripgrep.enable = true;
   programs.zellij.enable = true;
   programs.zoxide.enable = true;


### PR DESCRIPTION
## Summary

- Remove `programs.mise.enable` from the shared home-manager configuration.

mise is no longer used in this setup; this was the only reference in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)