### PR TITLE
feat: install mise from nixpkgs-unstable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,6 +12,7 @@ The central configuration file that defines all inputs and outputs.
 | Input | Source | Purpose |
 |-------|--------|---------|
 | `nixpkgs` | nixos/nixpkgs (25.11-small) | Main package source |
+| `nixpkgs-unstable` | nixos/nixpkgs (nixos-unstable) | Newer packages via the `unstable-packages` overlay (e.g. `mise`) |
 | `home-manager` | nix-community (25.11) | User environment management |
 | `nixvim` | nix-community (25.11) | Neovim configuration framework |
 | `nix-index-database` | nix-community | Weekly pre-built nix-index database for `nix-locate` and `command-not-found` |
@@ -21,12 +22,15 @@ The central configuration file that defines all inputs and outputs.
 - **nixosConfigurations**: `vm`
 - **homeConfigurations**: `nixos@linux-x86_64`, `nixos@linux-aarch64`, `henry@darwin-legacy` (x86_64), `henry@darwin` (aarch64)
 - **packages**: `home-manager` — Exposes the home-manager CLI from flake inputs, enabling `nix run '.#home-manager'` for bootstrapping without a prior installation.
-- **overlays**: `fix-inetutils`
+- **overlays**: `unstable-packages`, `fix-inetutils`
 - **devShells**: Provides `nixfmt-rfc-style` for all systems
 
 ## overlays
 
-Contains `default.nix` which provides the `fix-inetutils` overlay, a workaround for inetutils build failure on Darwin (nixpkgs#488689).
+Contains `default.nix` which provides:
+
+- `unstable-packages`: exposes the `nixpkgs-unstable` package set as `pkgs.unstable` (used for `mise`).
+- `fix-inetutils`: a workaround for inetutils build failure on Darwin (nixpkgs#488689).
 
 ## home-manager
 

--- a/flake.lock
+++ b/flake.lock
@@ -122,6 +122,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1780223022,
@@ -204,6 +220,7 @@
         "home-manager": "home-manager",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     # Home manager
     home-manager.url = "github:nix-community/home-manager/release-25.11";
@@ -20,6 +21,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       home-manager,
       ...
     }@inputs:

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -335,6 +335,10 @@
       };
     };
   };
+  programs.mise = {
+    enable = true;
+    package = pkgs.unstable.mise;
+  };
   programs.ripgrep.enable = true;
   programs.zellij.enable = true;
   programs.zoxide.enable = true;

--- a/home-manager/common/nixpkgs.nix
+++ b/home-manager/common/nixpkgs.nix
@@ -2,6 +2,7 @@
 {
   nixpkgs = {
     overlays = [
+      outputs.overlays.unstable-packages
       outputs.overlays.fix-inetutils
     ];
     config = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,5 +1,16 @@
-{ ... }:
+{ inputs, ... }:
+let
+  inherit (inputs) nixpkgs-unstable;
+in
 {
+  # Overlay to use packages from nixpkgs unstable channel
+  unstable-packages = final: _prev: {
+    unstable = import nixpkgs-unstable {
+      system = final.stdenv.hostPlatform.system;
+      config.allowUnfree = true;
+    };
+  };
+
   # Workaround for https://github.com/NixOS/nixpkgs/issues/488689
   # gnulib's error() macro passes dgettext() results as format strings,
   # triggering -Werror,-Wformat-security in openat-die.c


### PR DESCRIPTION
## Summary

Reinstall `mise`, but sourced from `nixpkgs-unstable` instead of the stable `25.11-small` channel.

This effectively reverts #56 (which dropped the unused `nixpkgs-unstable` input and `unstable-packages` overlay) and undoes #60 (which removed `mise`), now wiring `mise` to consume the overlay so the dependency is no longer unused.

### Changes

- **`flake.nix`**: re-add the `nixpkgs-unstable` input (`nixos-unstable`) and destructure it in `outputs`.
- **`overlays/default.nix`**: restore the `unstable-packages` overlay exposing `pkgs.unstable`.
- **`home-manager/common/nixpkgs.nix`**: register the `unstable-packages` overlay.
- **`home-manager/common/default.nix`**: re-enable `programs.mise` with `package = pkgs.unstable.mise`.
- **`ARCHITECTURE.md`**: document the input and overlay.
- **`flake.lock`**: pin `nixpkgs-unstable` to `331800d` (2026-05-31).

### Version

| Channel | mise |
|---------|------|
| stable (`25.11-small`) | 2025.11.7 |
| **unstable (this PR)** | **2026.5.15** |

## Test plan

- [x] `nix flake lock` succeeds
- [x] `programs.mise.package.version` evaluates to `2026.5.15`
- [x] `nix build --dry-run .#homeConfigurations."nixos@linux-x86_64".activationPackage` exits 0
- [x] formatted with `nixfmt-rfc-style`

🤖 Generated with [Claude Code](https://claude.com/claude-code)