### PR TITLE
feat: set Ghostty font size per platform (16 on macOS, 12 on Linux)

### DIFF
--- a/home-manager/common/ghostty/default.nix
+++ b/home-manager/common/ghostty/default.nix
@@ -22,7 +22,8 @@
       command = "${pkgs.fish}/bin/fish -l";
       theme = "Dracula";
       font-family = "Maple Mono NF CN";
-      font-size = 12;
+      # macOS renders at a larger physical size, so bump the font there.
+      font-size = if pkgs.stdenv.isDarwin then 16 else 12;
       copy-on-select = "clipboard";
       mouse-hide-while-typing = true;
       window-padding-x = 8;


### PR DESCRIPTION
## Summary

Ghostty `font-size` was hardcoded to `12`. macOS renders at a larger physical size, so the font now scales per platform:

- **macOS:** `16`
- **Linux:** `12`

Implemented with `pkgs.stdenv.isDarwin`, matching the platform-detection pattern already used elsewhere in the repo.

## Verification

```
$ nix eval .#homeConfigurations."henry@darwin".config.programs.ghostty.settings.font-size
[ 16 ]
$ nix eval .#homeConfigurations."nixos@linux-x86_64".config.programs.ghostty.settings.font-size
[ 12 ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)