### PR TITLE
fix: enable fontconfig so Linux Ghostty finds Maple Mono (ligatures)

### DIFF
--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -21,6 +21,11 @@
   # Add stuff for your user as you see fit:
   # programs.neovim.enable = true;
 
+  # Let fontconfig discover fonts installed via home.packages (e.g. Maple Mono
+  # NF CN). Without this it defaults to false, so Ghostty's fontconfig+freetype
+  # engine cannot find the family and falls back to a font without ligatures.
+  fonts.fontconfig.enable = true;
+
   # Enable home-manager and git
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
## Problem

Ghostty on Linux renders no ligatures with `font-family = "Maple Mono NF CN"`, while the same config works on macOS.

Root cause is **not** a Ghostty ligature setting (`calt` is on by default). On Linux Ghostty uses the fontconfig+freetype engine, but home-manager's `fonts.fontconfig.enable` defaults to `false`, so fonts installed via `home.packages` are never registered with fontconfig. `fc-match "Maple Mono NF CN"` therefore fell back to `Noto Sans`, which has no programming ligatures. macOS is unaffected because it uses CoreText and reads the installed TTFs directly.

## Fix

Set `fonts.fontconfig.enable = true` in the Linux home-manager config. This generates `~/.config/fontconfig/conf.d/10-hm-fonts.conf`, adding the nix profile font dir to fontconfig's search path.

## Verification

After `home-manager switch`:

| | before | after |
|---|---|---|
| `fc-match "Maple Mono NF CN"` | `Noto Sans` | `MapleMono-NF-CN-Regular` |
| `fc-list \| grep maple` | empty | all weights listed |
| `~/.config/fontconfig/conf.d/` | empty | `10-hm-fonts.conf` present |

Restart Ghostty (or reload config) to pick up the now-resolvable font; ligatures appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)