### PR TITLE
refactor: replace done fish plugin with Ghostty native notify-on-command-finish

### DIFF
--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -111,10 +111,6 @@
         src = pkgs.fishPlugins.fzf-fish.src;
       }
       {
-        name = "done";
-        src = pkgs.fishPlugins.done.src;
-      }
-      {
         name = "plugin-git";
         src = pkgs.fetchFromGitHub {
           owner = "jhillyerd";

--- a/home-manager/common/ghostty/default.nix
+++ b/home-manager/common/ghostty/default.nix
@@ -33,6 +33,12 @@
       # ssh-env forwards COLORTERM/TERM_PROGRAM* and sets TERM=xterm-256color;
       # ssh-terminfo installs Ghostty's terminfo on the remote on first connect.
       shell-integration-features = "cursor,sudo,title,ssh-env,ssh-terminfo";
+      # Replaces the `done` fish plugin: notify when a >5s command finishes while
+      # the window is unfocused. Detected via OSC 133 (native in fish 4.1+), so
+      # there is no shell subprocess / lsappinfo focus probe — which is what made
+      # the plugin intermittently hang in fish_postexec on macOS.
+      notify-on-command-finish = "unfocused";
+      notify-on-command-finish-action = "no-bell,notify";
       keybind = [
         "cmd+shift+,=reload_config"
         "ctrl+shift+,=reload_config"


### PR DESCRIPTION
## Summary

Replaces the `done` fish plugin with Ghostty's native `notify-on-command-finish`.

The `done` plugin intermittently hung in `fish_postexec` on macOS because of its `lsappinfo` focus probe. Ghostty's native `notify-on-command-finish` is driven by OSC 133 (native in fish 4.1+) and spawns no shell subprocess, so it avoids the hang while preserving the same behavior: notify when a command running longer than 5s finishes while the window is unfocused.

## Changes

- `home-manager/common/default.nix`: remove the `done` fish plugin.
- `home-manager/common/ghostty/default.nix`: add `notify-on-command-finish = "unfocused"` and `notify-on-command-finish-action = "no-bell,notify"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)