### PR TITLE
fix: add Nix profile to fish PATH for GUI-launched shells on macOS

### DIFF
--- a/home-manager/darwin/default.nix
+++ b/home-manager/darwin/default.nix
@@ -29,6 +29,17 @@
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
   home.stateVersion = "24.05";
 
+  # The Nix multi-user installer only adds the profile to /etc/zshrc and
+  # /etc/bashrc, never to fish. Ghostty launches `fish -l` directly from the
+  # GUI (via launchd), so fish never inherits a login shell's PATH and the Nix
+  # profile is missing. Bare commands such as `gpgconf` and the snippets emitted
+  # by `atuin init` / `fzf --fish` then fail at startup. loginShellInit runs in
+  # the login block, before interactiveShellInit, so PATH is ready in time.
+  programs.fish.loginShellInit = ''
+    fish_add_path --prepend --global /nix/var/nix/profiles/default/bin
+    fish_add_path --prepend --global $HOME/.nix-profile/bin
+  '';
+
   programs.fish.interactiveShellInit = ''
     # GPG agent
     set -gx GPG_TTY (tty)


### PR DESCRIPTION
## Summary

The Nix multi-user installer only wires its profile into `/etc/zshrc` and `/etc/bashrc`, never fish. Ghostty launches `fish -l` directly via launchd, so fish never inherits a login shell's PATH and the Nix profile is absent. Bare commands such as `gpgconf` and the snippets emitted by `atuin init` and `fzf --fish` then fail at shell startup.

## Changes

- Add `programs.fish.loginShellInit` to prepend the Nix profile bin dirs (`/nix/var/nix/profiles/default/bin` and `$HOME/.nix-profile/bin`) in the login block, before `interactiveShellInit` runs — so PATH is ready in time.

## Testing

- `nix flake check` / Home Manager build (please confirm in your environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)