### PR TITLE
refactor: remove macOS Intel (x86_64-darwin) legacy config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-- Hardware: Supports macOS (both Intel and Apple Silicon) and Linux (x86_64 and aarch64).
+- Hardware: Supports macOS (Apple Silicon) and Linux (x86_64 and aarch64).
 - This configuration is derived from the standard version of [Misterio77/nix-starter-configs](https://github.com/Misterio77/nix-starter-configs/tree/972935c1b35d8b92476e26b0e63a044d191d49c3/standard).
 
 ## flake.nix
@@ -20,7 +20,7 @@ The central configuration file that defines all inputs and outputs.
 ### Outputs
 
 - **nixosConfigurations**: `vm`
-- **homeConfigurations**: `nixos@linux-x86_64`, `nixos@linux-aarch64`, `henry@darwin-legacy` (x86_64), `henry@darwin` (aarch64)
+- **homeConfigurations**: `nixos@linux-x86_64`, `nixos@linux-aarch64`, `henry@darwin` (aarch64)
 - **packages**: `home-manager` — Exposes the home-manager CLI from flake inputs, enabling `nix run '.#home-manager'` for bootstrapping without a prior installation.
 - **overlays**: `unstable-packages`, `fix-inetutils`
 - **devShells**: Provides `nixfmt-rfc-style` for all systems

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ _HALF_MEM   = $(shell free -m | awk '/^Mem:/{print int($$2/2)}')
 ifeq ($(_UNAME),Darwin)
   ifeq ($(_ARCH),arm64)
     _HM_TARGET := henry@darwin
-  else ifeq ($(_ARCH),x86_64)
-    _HM_TARGET := henry@darwin-legacy
   endif
 else ifeq ($(_UNAME),Linux)
   ifeq ($(_ARCH),aarch64)

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
       forAllSystems = nixpkgs.lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
     in
@@ -83,13 +82,6 @@
             inherit inputs outputs;
           };
           modules = [ ./home-manager/linux ];
-        };
-        "henry@darwin-legacy" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.x86_64-darwin; # Home-manager requires 'pkgs' instance
-          extraSpecialArgs = {
-            inherit inputs outputs;
-          };
-          modules = [ ./home-manager/darwin ];
         };
         "henry@darwin" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.aarch64-darwin; # Home-manager requires 'pkgs' instance


### PR DESCRIPTION
## Summary

Drop support for Intel Macs, which are no longer in use. Removes the `henry@darwin-legacy` Home Manager configuration and all related plumbing.

## Changes

- **flake.nix**: Remove the `henry@darwin-legacy` homeConfiguration and drop `x86_64-darwin` from `forAllSystems` (no longer needed for `packages`/`devShells`).
- **Makefile**: Remove the `x86_64` Darwin branch from Home Manager target resolution. Intel Macs now fall through to the existing "Unsupported platform" guard.
- **ARCHITECTURE.md**: Reflect Apple Silicon-only macOS support and drop `henry@darwin-legacy` from the outputs list.

The shared `home-manager/darwin/` module is untouched — it is still used by the `henry@darwin` (aarch64) configuration.

## Testing

- `nix eval '.#homeConfigurations' --apply builtins.attrNames` → `[ "henry@darwin" "nixos@linux-aarch64" "nixos@linux-x86_64" ]` (legacy gone)
- `make` on local arm64 Darwin still resolves `_HM_TARGET := henry@darwin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)