### PR TITLE
chore: add ntfy-sh CLI to common home packages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Common configuration shared between Darwin and Linux.
 
 - **Shell**: Fish with Starship prompt, fish plugins (autopair, fzf-fish, done, plugin-git)
 - **Development**: Git (with GPG signing, delta for diffs), GitHub CLI, direnv, FZF, ripgrep, fd, git-extras, gnumake, fnm
-- **Terminal tools**: Atuin (shell history), bat, lsd, lazygit, zoxide, gping, procs, spacer, xh
+- **Terminal tools**: Atuin (shell history), bat, lsd, lazygit, zoxide, gping, procs, spacer, xh, ntfy-sh (push notifications)
 - **Security**: GPG, password-store
 - **Services**: GPG Agent, Syncthing
 

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -25,6 +25,7 @@
       gnumake
       gping
       nixfmt-rfc-style
+      ntfy-sh
       procs
       spacer
       watchexec


### PR DESCRIPTION
## Summary

- Add `ntfy-sh` to the common `home.packages` so the `ntfy` CLI is available on all platforms (macOS / Linux).
- Update `ARCHITECTURE.md` terminal tools list accordingly.

## Why

Enables push notifications via the `ntfy` CLI (e.g. `ntfy publish ...`).

## Verification

- `make dry-run` passes; resolves `ntfy-sh 2.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)