### PR TITLE
chore: upgrade NixOS from 25.11 to 26.05

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,10 +11,10 @@ The central configuration file that defines all inputs and outputs.
 
 | Input | Source | Purpose |
 |-------|--------|---------|
-| `nixpkgs` | nixos/nixpkgs (25.11-small) | Main package source |
+| `nixpkgs` | nixos/nixpkgs (26.05-small) | Main package source |
 | `nixpkgs-unstable` | nixos/nixpkgs (nixos-unstable) | Newer packages via the `unstable-packages` overlay (e.g. `mise`) |
-| `home-manager` | nix-community (25.11) | User environment management |
-| `nixvim` | nix-community (25.11) | Neovim configuration framework |
+| `home-manager` | nix-community (26.05) | User environment management |
+| `nixvim` | nix-community (26.05) | Neovim configuration framework |
 | `nix-index-database` | nix-community | Weekly pre-built nix-index database for `nix-locate` and `command-not-found` |
 
 ### Outputs

--- a/flake.lock
+++ b/flake.lock
@@ -8,34 +8,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -44,45 +26,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1783221248,
+        "narHash": "sha256-ESQnuNHEDChsB4IxoLRhscVahqkDWkTb+qdIz8euYt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "af2beae5f0fae0a4310cc0e6aef2572f56090353",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "ixx": {
-      "inputs": {
-        "flake-utils": [
-          "nixvim",
-          "nuschtosSearch",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixvim",
-          "nuschtosSearch",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1754860581,
-        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
-        "owner": "NuschtOS",
-        "repo": "ixx",
-        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "ref": "v0.1.1",
-        "repo": "ixx",
         "type": "github"
       }
     },
@@ -93,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1783414108,
+        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
         "type": "github"
       },
       "original": {
@@ -108,27 +62,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1782847225,
+        "narHash": "sha256-JC9PjqKYG9ve5U8aDOLQipp3+KLANBHUvGdLZlxzdKI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "95ca1e203c0750115fd4a6f17d5a245dfe6b1edd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -140,32 +94,32 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781509190,
-        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
+        "lastModified": 1783477845,
+        "narHash": "sha256-O91YqaOFG3XXnhlxWUCrRq77LBLBopgQBqKp23In8kg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
+        "rev": "559746b7f3182241a9e265e89864c59d5b28b16a",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11-small",
+        "ref": "nixos-26.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1768323494,
-        "narHash": "sha256-yBXJLE6WCtrGo7LKiB6NOt6nisBEEkguC/lq/rP3zRQ=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c3e5ec5df46d3aeee2a1da0bfedd74e21f4bf3a",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -174,44 +128,20 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_3",
-        "nuschtosSearch": "nuschtosSearch",
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1780865908,
-        "narHash": "sha256-UMwL+pE2I49q6qOV8w6pnuF3utb1qQuofmprBAhOU6A=",
+        "lastModified": 1782919967,
+        "narHash": "sha256-pRwjfB5HQJ3m8J8bOR43pPHtHI7VUJSqwLA3P06cOY0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "68e314303bc60b8a58cdd2f361013809620b2473",
+        "rev": "667c8471f4a0fb24d702d1a61af8609f1a5f1ba6",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixvim",
-        "type": "github"
-      }
-    },
-    "nuschtosSearch": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "ixx": "ixx",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768249818,
-        "narHash": "sha256-ANfn5OqIxq3HONPIXZ6zuI5sLzX1sS+2qcf/Pa0kQEc=",
-        "owner": "NuschtOS",
-        "repo": "search",
-        "rev": "b6f77b88e9009bfde28e2130e218e5123dc66796",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "repo": "search",
         "type": "github"
       }
     },
@@ -225,21 +155,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,14 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05-small";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     # Home manager
-    home-manager.url = "github:nix-community/home-manager/release-25.11";
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
 
     # nixvim
-    nixvim.url = "github:nix-community/nixvim/nixos-25.11";
+    nixvim.url = "github:nix-community/nixvim/nixos-26.05";
 
     # nix-index database (pre-built nix-index database for command-not-found / nix-locate)
     nix-index-database.url = "github:nix-community/nix-index-database";

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
         in
         {
           default = pkgs.mkShellNoCC {
-            packages = [ pkgs.nixfmt-rfc-style ];
+            packages = [ pkgs.nixfmt ];
           };
         }
       );

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -25,7 +25,9 @@
       gnumake
       gping
       nixfmt
-      ntfy-sh
+      # stable's ntfy-sh 2.23.0 fails to build on darwin
+      # (undefined maybeRunAsService/sigHandlerConfigReload); 2.25.0 builds fine
+      unstable.ntfy-sh
       procs
       spacer
       watchexec

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -14,12 +14,9 @@
   home.packages =
     with pkgs;
     [
-      # cargo dev tools: pulled from the unstable overlay to track crates.io
-      # releases more closely than the stable channel (also avoids stable's
-      # cargo-llvm-cov being marked broken)
-      unstable.cargo-hack
-      unstable.cargo-llvm-cov
-      unstable.cargo-msrv
+      cargo-hack
+      cargo-llvm-cov
+      cargo-msrv
       fd
       git-extras
       gnumake

--- a/home-manager/common/default.nix
+++ b/home-manager/common/default.nix
@@ -24,7 +24,7 @@
       git-extras
       gnumake
       gping
-      nixfmt-rfc-style
+      nixfmt
       ntfy-sh
       procs
       spacer

--- a/home-manager/common/nixvim/lsp.nix
+++ b/home-manager/common/nixvim/lsp.nix
@@ -3,7 +3,7 @@
   programs.nixvim = {
     extraPackages = with pkgs; [
       nodejs
-      nodePackages.prettier
+      prettier
       stylua
     ];
     plugins.cmp = {


### PR DESCRIPTION
## Summary

Upgrade the configuration from the NixOS 25.11 release to 26.05, plus the
compatibility fixes the bump surfaced.

Version-pinned flake inputs bumped to their 26.05 branches:

| Input | Before | After |
|-------|--------|-------|
| `nixpkgs` | `nixos-25.11-small` | `nixos-26.05-small` |
| `home-manager` | `release-25.11` | `release-26.05` |
| `nixvim` | `nixos-25.11` | `nixos-26.05` |

## Fixes surfaced by the upgrade

- **`nodePackages` removed** — `nodePackages.prettier` → top-level `pkgs.prettier` (3.8.3) in the nixvim LSP config.
- **`nixfmt-rfc-style` deprecated** — 26.05 aliases it to `pkgs.nixfmt` and warns; switched the devShell formatter and the common home package to `pkgs.nixfmt`.
- **`ntfy-sh` fails to build on darwin** — stable's 2.23.0 fails to compile (`undefined: maybeRunAsService` / `sigHandlerConfigReload`); sourced from the unstable overlay (2.25.0) instead. Only reproduces on a real build (`make switch`), not `make dry-run`.

## Housekeeping enabled by the upgrade

- **cargo dev tools back to stable** — 26.05 no longer marks `cargo-llvm-cov` broken, so `cargo-hack` / `cargo-llvm-cov` / `cargo-msrv` move off the unstable overlay (versions equal to or one patch behind unstable). Stale justifying comment removed.

## Intentionally unchanged

- `stateVersion` stays at `24.05` — it tracks the initial install, not the current release.
- `nixpkgs-unstable` and `nix-index-database` are unversioned inputs.
- `mise` stays on unstable (frequent release cadence); `ntfy-sh` stays on unstable (darwin build failure above).

## Verification

- `make switch` (`henry@darwin`) → exit 0; `ntfy --version` reports 2.25.0, cargo tools resolve on PATH
- `make dry-run` → exit 0
- `make fmt` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)