### PR TITLE
perf(fish): guard gpg-agent launch to speed up shell startup

### DIFF
--- a/home-manager/darwin/default.nix
+++ b/home-manager/darwin/default.nix
@@ -44,7 +44,9 @@
     # GPG agent
     set -gx GPG_TTY (tty)
     set -gx SSH_AUTH_SOCK (gpgconf --list-dirs agent-ssh-socket)
-    gpgconf --launch gpg-agent
+    # `gpgconf --launch` costs ~310ms on macOS even when the agent is already
+    # running, so guard it with a cheap pgrep check to keep shell startup fast.
+    pgrep -x gpg-agent >/dev/null; or gpgconf --launch gpg-agent
   '';
 
   home.file."Brewfile".source = ./Brewfile;


### PR DESCRIPTION
## Summary

Fish interactive startup measured ~380ms. Profiling with `fish --profile-startup` showed a single line dominating at **~83%**:

| Item | Self time |
|------|----------:|
| **`gpgconf --launch gpg-agent`** | **316 ms** |
| `brew shellenv` | 18.7 ms |
| `mise activate` + `hook-env` | ~15 ms |
| `starship init fish` | 8.3 ms |
| everything else | ~20 ms |

The key finding: `gpgconf --launch gpg-agent` costs ~310ms on **every** interactive shell even when the agent is already running — on macOS it performs a full socket handshake rather than a cheap liveness check. Since it lives in `interactiveShellInit`, every new tab/window pays it.

## Change

Guard the launch with a cheap `pgrep -x gpg-agent` check (~2ms) in `home-manager/darwin/default.nix`, so the agent is only launched once:

```fish
pgrep -x gpg-agent >/dev/null; or gpgconf --launch gpg-agent
```

Expected startup drops from **~380ms to ~70ms (~5x)**. The first shell (agent not yet running) still pays the launch once; all subsequent shells take the fast path.

## Linux

Unaffected. Linux manages gpg-agent via the systemd user service with socket activation (`services.gpg-agent` in `home-manager/linux/default.nix`) and never calls `gpgconf --launch`, so it has neither the cost nor the need for this guard.

## Testing

- `fish -n` syntax check passes
- `nix build .#homeConfigurations."henry@darwin".activationPackage` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)