### PR TITLE
chore: group github-actions dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Enable Dependabot `groups` for the `github-actions` ecosystem so all action updates are consolidated into a single PR instead of one PR per action.

## Details

Adds a `groups` block matching all patterns (`*`) under the existing `github-actions` update config, keeping the current weekly schedule, 7-day cooldown, and PR limit unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)