### PR TITLE
feat(ghostty): loosen line spacing by 10%

### DIFF
--- a/home-manager/common/ghostty/default.nix
+++ b/home-manager/common/ghostty/default.nix
@@ -24,6 +24,9 @@
       font-family = "Maple Mono NF CN";
       # macOS renders at a larger physical size, so bump the font there.
       font-size = if pkgs.stdenv.isDarwin then 16 else 12;
+      # Loosen line spacing by 10% of the font's default cell height for
+      # readability; relative so it tracks each platform's font-size.
+      adjust-cell-height = "10%";
       copy-on-select = "clipboard";
       mouse-hide-while-typing = true;
       window-padding-x = 8;


### PR DESCRIPTION
## Summary

Set `adjust-cell-height` to `10%` in the Ghostty home-manager module so terminal lines get a bit more breathing room.

Ghostty has no `line-height` option; `adjust-cell-height` is the equivalent knob and is relative to the font's default cell height, so it tracks the existing per-platform `font-size` and needs no `isDarwin` split.

## Test plan

- `nix flake check --no-build` passes.
- After rebuild, `~/.config/ghostty/config` contains `adjust-cell-height = 10%` and reloading Ghostty (`cmd+shift+,`) shows the wider line spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)