### PR TITLE
chore(ci): run build jobs in parallel with check

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,7 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+# Superseded runs on the same ref are pointless once a newer commit is pushed;
+# main is exempt so every merged commit keeps a complete run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
+  # check, build-nixos and build-home-manager are intentionally independent:
+  # formatting/eval failures and build failures are separate signals, so gating
+  # the builds behind check only delayed the whole run by check's duration.
   check:
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +32,6 @@ jobs:
 
   build-nixos:
     runs-on: ubuntu-latest
-    needs: check
     strategy:
       matrix:
         config: [vm]
@@ -36,7 +44,6 @@ jobs:
 
   build-home-manager:
     runs-on: ubuntu-latest
-    needs: check
     strategy:
       matrix:
         config:


### PR DESCRIPTION
## Summary

- Drop `needs: check` from `build-nixos` and `build-home-manager`. A formatting/eval failure and a build failure are independent signals, so the gate only added `check`'s ~2min to every run's wall clock. Measured on the last runs: `check` 1m54s, then builds 3m35s / 4m06s — total ~6min. Running all three at once should land around ~4min.
- Add a `concurrency` group so superseded runs on a PR branch are cancelled rather than competing for runners. `main` is exempt so every merged commit keeps a complete run.

## Trade-off

When formatting fails, the build jobs now burn runner minutes instead of being skipped. Given this repo's PR volume that is cheaper than adding 2min to every green run.

## Test plan

- This PR's own CI run: the three jobs should start simultaneously and the total should be near the slowest build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)